### PR TITLE
Switch to Debian 12, latest Owncloud package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # Create the directory in which the scripts will be stored
 RUN mkdir -p /opt/ownCloud/log
@@ -26,8 +26,8 @@ RUN apt update \
     /usr/share/lintian
 
 # Add the ownCloud repository and install it
-RUN echo 'deb https://download.owncloud.com/desktop/ownCloud/stable/2.11.1.8946/linux/Debian_11/ /' > /etc/apt/sources.list.d/owncloud-client.list \
-    && wget -nv 'https://download.owncloud.com/desktop/ownCloud/stable/latest/linux/Debian_11/Release.key' -O /tmp/Release.key \
+RUN echo 'deb https://download.owncloud.com/desktop/ownCloud/stable/latest/linux/Debian_12/ /' > /etc/apt/sources.list.d/owncloud-client.list \
+    && wget -nv 'https://download.owncloud.com/desktop/ownCloud/stable/latest/linux/Debian_12/Release.key' -O - | gpg --dearmor | tee /etc/apt/trusted.gpg.d/owncloud-client.gpg > /dev/null \
     && apt-key add - < /tmp/Release.key \
     && apt update \
     && apt install -yq --no-install-recommends \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,14 @@ occlient:
   image: dyonr/owncloud-client
   volumes:
     - ${PWD}/mydata:/ocdata
+    - ${PWD}/logs:/opt/ownCloud/log
   environment:
     - OC_USER=myuser
     - OC_PASS=mypass
     - OC_PROTO=https
     - OC_SERVER=myocserver.com
     - OC_URLPATH=/
-    - OC_WEBDAV=remote.php/webdav
+    - OC_WEBDAV=
     - OC_FILEPATH=/
     - TRUST_SELFSIGN=0
     - SYNC_HIDDEN=0
@@ -16,4 +17,3 @@ occlient:
     - RUN_INTERVAL=30
     - RUN_UID=99
     - RUN_GID=100
-

--- a/run.sh
+++ b/run.sh
@@ -20,9 +20,9 @@ if [ "$SILENCE_OUTPUT" -eq 1 ]; then
 fi
 
 echo "[INFO] Running owncloudcmd as following:" | ts '%Y-%m-%d %H:%M:%.S'
-echo "[INFO] owncloudcmd $SELFSIGN $SYNCHIDDEN $SILENCEOUTPUT -n --non-interactive /ocdata $OC_PROTO://$OC_SERVER$OC_URLPATH$OC_WEBDAV$OC_FILEPATH" | ts '%Y-%m-%d %H:%M:%.S'
+echo "[INFO] owncloudcmd $SELFSIGN $SYNCHIDDEN $SILENCEOUTPUT --non-interactive --user $OC_USER --password $OC_PASS  /ocdata $OC_PROTO://$OC_SERVER$OC_URLPATH$OC_WEBDAV $OC_FILEPATH" | ts '%Y-%m-%d %H:%M:%.S'
 while true
 do 
-	su - occlient -c "owncloudcmd $SELFSIGN $SYNCHIDDEN $SILENCEOUTPUT -n --non-interactive /ocdata $OC_PROTO://$OC_SERVER$OC_URLPATH$OC_WEBDAV$OC_FILEPATH &> /opt/ownCloud/log/latest.log"
+	su - occlient -c "owncloudcmd $SELFSIGN $SYNCHIDDEN $SILENCEOUTPUT --non-interactive --user $OC_USER --password $OC_PASS  /ocdata $OC_PROTO://$OC_SERVER$OC_URLPATH$OC_WEBDAV $OC_FILEPATH &> /opt/ownCloud/log/latest.log"
 	sleep $RUN_INTERVAL
 done


### PR DESCRIPTION
Fixes:
- Updated Debian image
- Updated ownCloud client, as of writing 5.2.1.13040
- Adjust parameters for newest owncloudcmd arguments
- Defaults to $OC_WEBDAV being empty, newest owncloudcmd adds URL paths automatically

The old image would only get 403 FORBIDDEN errors with the ownCloud server I'm working with.